### PR TITLE
Remove actor related deprecation warning

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -198,10 +198,10 @@ function enable() {
     boxlayout.add(button);
     repaintConnection = binaryCalc.connect('repaint', _repaintevent);
     if (!oldClock) {
-        oldClock = Main.panel.statusArea['dateMenu'].actor.get_child_at_index(0);
+        oldClock = Main.panel.statusArea['dateMenu'].get_child_at_index(0);
     }
-    Main.panel.statusArea['dateMenu'].actor.remove_child(oldClock);
-    Main.panel.statusArea['dateMenu'].actor.insert_child_at_index(boxlayout, 0);
+    Main.panel.statusArea['dateMenu'].remove_child(oldClock);
+    Main.panel.statusArea['dateMenu'].insert_child_at_index(boxlayout, 0);
 
     if (updateClockId != 0) {
         dateMenu._clock.disconnect(updateClockId);
@@ -211,8 +211,8 @@ function enable() {
 }
 
 function disable() {
-    Main.panel.statusArea['dateMenu'].actor.remove_child(boxlayout);
-    Main.panel.statusArea['dateMenu'].actor.insert_child_at_index(oldClock, 0);
+    Main.panel.statusArea['dateMenu'].remove_child(boxlayout);
+    Main.panel.statusArea['dateMenu'].insert_child_at_index(oldClock, 0);
     if (!dateMenu) {
         return;
     }

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "adds a binary clock to the gnome bar", 
   "name": "binaryclock", 
   "shell-version": [
-    "3.28", "3.32.2", "3.34","3.36.7","3.38"
+    "3.28", "3.32.2", "3.34", "3.36.7", "3.38", "40"
   ], 
   "url": "https://github.com/vancha/gnomeShellBinaryClock/", 
   "uuid": "binaryclock@vancha.march", 


### PR DESCRIPTION
> Usage of object.actor is deprecated for DateMenuButton

I don't know Gnome API, getting through similar problems in the other Gnome extensions, it seems that certain functions/methods can be called on the main object directly. See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/487

I also bumped compatibility to handle Gnome 40 - it works fine on Fedora 34.

Fixes #5.