### PR TITLE
Declare Gnome 41 compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "adds a binary clock to the gnome bar", 
   "name": "binaryclock", 
   "shell-version": [
-    "3.28", "3.32.2", "3.34", "3.36.7", "3.38", "40"
+    "3.28", "3.32.2", "3.34", "3.36.7", "3.38", "40", "41"
   ], 
   "url": "https://github.com/vancha/gnomeShellBinaryClock/", 
   "uuid": "binaryclock@vancha.march", 


### PR DESCRIPTION
It just works with Gnome Shell 41.1 on Fedora 35.

You might want to release a new version to the extension portal.