### PR TITLE
Declare Gnome 42 and 43 compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "adds a binary clock to the gnome bar", 
   "name": "binaryclock", 
   "shell-version": [
-    "3.28", "3.32.2", "3.34", "3.36.7", "3.38", "40", "41"
+    "3.28", "3.32.2", "3.34", "3.36.7", "3.38", "40", "41", "42", "43"
   ], 
   "url": "https://github.com/vancha/gnomeShellBinaryClock/", 
   "uuid": "binaryclock@vancha.march", 


### PR DESCRIPTION
It seems to work fine in Fedora 37.